### PR TITLE
指令匹配失败时提供候选

### DIFF
--- a/src/core/bot/decorator.py
+++ b/src/core/bot/decorator.py
@@ -2,6 +2,8 @@ import logging
 from dataclasses import dataclass
 from typing import Callable
 
+from thefuzz import process
+
 from src.core.bot.message import MessageType
 from src.core.bot.perm import PermissionLevel
 
@@ -128,6 +130,39 @@ def scheduled(cron: str, targets: list[str], no_target: bool = False):
 def get_command_count() -> int:
     """获取当前注册的主指令数量 (不包括别名)"""
     return sum(len(module_commands) for module_commands in __commands_primary__.values())
+
+
+def find_similar_commands(input_cmd: str, limit: int = 3,
+                          permission_level: PermissionLevel = PermissionLevel.USER) -> list[str]:
+    """
+    在已注册的指令中模糊查找与输入最相似的候选指令。
+
+        :param input_cmd: 用户输入的指令，如 "/cf"
+        :param limit: 返回候选的最大数量
+        :param permission_level: 用户的权限等级，不会返回权限不足的指令
+        :return: 候选指令名列表，按相似度降序
+    """
+    if not input_cmd:
+        return []
+
+    command_levels: dict[str, PermissionLevel] = {}
+    for module_commands in __commands__.values():
+        for cmd, (_, execute_level, _, _) in module_commands.items():
+            if not cmd.startswith('/'):
+                continue
+            name = cmd[:-1] if cmd.endswith('*') else cmd
+            if name not in command_levels:
+                command_levels[name] = execute_level
+
+    candidates = process.extract(input_cmd, list(command_levels.keys()), limit=limit)
+
+    suggestions: list[str] = []
+    for candidate, ratio in candidates:
+        if ratio >= 50 and candidate not in suggestions and command_levels[candidate] <= permission_level:
+            suggestions.append(candidate)
+        if len(suggestions) >= limit:
+            break
+    return suggestions
 
 
 def get_command_alias_count() -> int:

--- a/src/core/bot/decorator.py
+++ b/src/core/bot/decorator.py
@@ -154,11 +154,13 @@ def find_similar_commands(input_cmd: str, limit: int = 3,
             if name not in command_levels:
                 command_levels[name] = execute_level
 
-    candidates = process.extract(input_cmd, list(command_levels.keys()), limit=limit)
+    accessible_commands = [name for name, level in command_levels.items()
+                           if level <= permission_level]
+    candidates = process.extract(input_cmd, accessible_commands, limit=limit)
 
     suggestions: list[str] = []
     for candidate, ratio in candidates:
-        if ratio >= 50 and candidate not in suggestions and command_levels[candidate] <= permission_level:
+        if ratio >= 50 and candidate not in suggestions:
             suggestions.append(candidate)
         if len(suggestions) >= limit:
             break

--- a/src/core/bot/interact.py
+++ b/src/core/bot/interact.py
@@ -5,6 +5,7 @@ from typing import Callable
 from pypinyin import pinyin, Style
 from thefuzz import process
 
+from src.core.bot.decorator import find_similar_commands
 from src.core.bot.message import RobotMessage
 from src.core.constants import Constants
 from src.core.util.tools import check_is_int
@@ -15,6 +16,19 @@ def no_reply():
     无回复
     """
     pass
+
+
+def reply_command_not_found(message: RobotMessage, content: str):
+    """
+    回复未匹配到的 '/' 指令，并附上模糊查找得到的候选指令
+    """
+    suggestions = find_similar_commands(content, limit=3,
+                                        permission_level=message.user_permission_level)
+    if suggestions:
+        message.reply("没有找到该指令，猜你想找：\n" +
+                      "\n".join(f"{suggestion}" for suggestion in suggestions), modal_words=False)
+    else:
+        message.reply("没有找到该指令，输入 /help 查看可用指令")
 
 
 def reply_key_words(message: RobotMessage, content: str):

--- a/src/core/bot/transit.py
+++ b/src/core/bot/transit.py
@@ -8,7 +8,7 @@ from typing import Callable
 from apscheduler.triggers.cron import CronTrigger
 
 from src.core.bot.decorator import __commands__, __scheduled_jobs__
-from src.core.bot.interact import reply_key_words, no_reply
+from src.core.bot.interact import reply_key_words, no_reply, reply_command_not_found
 from src.core.bot.message import RobotMessage, MessageType
 from src.core.constants import Constants
 from src.core.util.exception import UnauthorizedError
@@ -68,7 +68,7 @@ def get_message_id(message: RobotMessage) -> MessageID:
         if message.is_guild_public() or message.is_group_public():
             return MessageID("default.manual", "no_reply")
 
-        if '/' in func:
+        if func.startswith('/'):
             return MessageID("default.manual", "reply_not_implemented")
         else:
             return MessageID("default.manual", "reply_key_words_func")
@@ -123,8 +123,8 @@ def handle_message(message: RobotMessage, message_id: MessageID):
             None: (no_reply, {}),
             MessageID("default.manual", "no_reply"): (no_reply, {}),
             MessageID("default.manual", "reply_not_implemented"): (
-                message.reply,
-                {"content": "其他指令还在开发中"}
+                reply_command_not_found,
+                {"message": message, "content": message.tokens[0].lower()}
             ),
             MessageID("default.manual", "reply_key_words_empty"): (
                 reply_key_words,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 未识别的斜杠命令现在会提供最多三条相似命令建议。
  * 建议内容会根据用户权限进行筛选。
  * 无匹配建议时，将提示使用 `/help` 获取帮助。

* **问题修复**
  * 优化斜杠命令识别逻辑，仅将以 `/` 开头的内容视为命令。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->